### PR TITLE
PeripheralRingMeshGenerator: small change for readability, updated loops to be range-based.

### DIFF
--- a/framework/src/utils/FillBetweenPointVectorsTools.C
+++ b/framework/src/utils/FillBetweenPointVectorsTools.C
@@ -515,19 +515,14 @@ isBoundarySimpleClosedLoop(MeshBase & mesh,
     if (std::get<2>(side_list_tmp[i]) == bid)
     {
       // store two nodes of each side
-      boundary_node_assm.push_back(std::make_pair(mesh.elem_ptr(std::get<0>(side_list_tmp[i]))
-                                                      ->side_ptr(std::get<1>(side_list_tmp[i]))
-                                                      ->node_id(0),
-                                                  mesh.elem_ptr(std::get<0>(side_list_tmp[i]))
-                                                      ->side_ptr(std::get<1>(side_list_tmp[i]))
-                                                      ->node_id(1)));
+      const auto elem = mesh.elem_ptr(std::get<0>(side_list_tmp[i]));
+      const auto side = elem->side_ptr(std::get<1>(side_list_tmp[i]));
+      boundary_node_assm.push_back(std::make_pair(side->node_id(0), side->node_id(1)));
       // see if there is a midpoint
-      if (mesh.elem_ptr(std::get<0>(side_list_tmp[i]))->side_type(std::get<1>(side_list_tmp[i])) ==
-          EDGE3)
+      const auto & side_type = elem->side_type(std::get<1>(side_list_tmp[i]));
+      if (side_type == EDGE3)
         boundary_midpoint_node_list.push_back(
-            mesh.elem_ptr(std::get<0>(side_list_tmp[i]))
-                ->node_id(mesh.elem_ptr(std::get<0>(side_list_tmp[i]))->n_vertices() +
-                          std::get<1>(side_list_tmp[i])));
+            elem->node_id(elem->n_vertices() + std::get<1>(side_list_tmp[i])));
       else
         boundary_midpoint_node_list.push_back(DofObject::invalid_id);
     }

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -37,7 +37,7 @@ changeBoundaryId(MeshBase & mesh,
   for (auto & elem : as_range(mesh.level_elements_begin(0), mesh.level_elements_end(0)))
   {
     unsigned int n_sides = elem->n_sides();
-    for (unsigned int s = 0; s != n_sides; ++s)
+    for (const auto s : make_range(n_sides))
     {
       boundary_info.boundary_ids(elem, s, old_ids);
       if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
@@ -106,7 +106,7 @@ getBoundaryIDs(const MeshBase & mesh,
       max_boundary_id > max_boundary_local_id ? max_boundary_id : max_boundary_local_id;
 
   std::vector<BoundaryID> ids(boundary_name.size());
-  for (unsigned int i = 0; i < boundary_name.size(); i++)
+  for (const auto i : index_range(boundary_name))
   {
     if (boundary_name[i] == "ANY_BOUNDARY_ID")
     {
@@ -160,7 +160,7 @@ getSubdomainIDs(const MeshBase & mesh, const std::vector<SubdomainName> & subdom
 {
   std::vector<SubdomainID> ids(subdomain_name.size());
 
-  for (unsigned int i = 0; i < subdomain_name.size(); i++)
+  for (const auto i : index_range(subdomain_name))
     ids[i] = MooseMeshUtils::getSubdomainID(subdomain_name[i], mesh);
 
   return ids;
@@ -328,7 +328,7 @@ isCoPlanar(const std::vector<Point> vec_pts)
   // Assuming that overlapped Points are allowed, the Points that are overlapped with vec_pts[0] are
   // removed before further calculation.
   std::vector<Point> vec_pts_nonzero{vec_pts[0]};
-  for (unsigned int i = 1; i < vec_pts.size(); i++)
+  for (const auto i : index_range(vec_pts))
     if (!MooseUtils::absoluteFuzzyEqual((vec_pts[i] - vec_pts[0]).norm(), 0.0))
       vec_pts_nonzero.push_back(vec_pts[i]);
   // 3 or fewer points are always coplanar
@@ -336,7 +336,7 @@ isCoPlanar(const std::vector<Point> vec_pts)
     return true;
   else
   {
-    for (unsigned int i = 1; i < vec_pts_nonzero.size() - 1; i++)
+    for (const auto i : make_range(vec_pts_nonzero.size() - 1))
     {
       const Point tmp_pt = (vec_pts_nonzero[i] - vec_pts_nonzero[0])
                                .cross(vec_pts_nonzero[i + 1] - vec_pts_nonzero[0]);


### PR DESCRIPTION
The PR defines and uses some intermediate variables to improve readability in the `isBoundarySimpleClosedLoop` function. It also updates for loops to be range-based for loops in order to conform with the MOOSE code standard.
